### PR TITLE
fix: color hover border accordion

### DIFF
--- a/src/azion-dark/variables/_panel.scss
+++ b/src/azion-dark/variables/_panel.scss
@@ -108,7 +108,7 @@ $accordionHeaderHoverBg: var(--surface-hover);
 
 /// Border of an accordion panel header in hover state
 /// @group panel
-$accordionHeaderHoverBorderColor: $panelHeaderBorder;
+$accordionHeaderHoverBorderColor: var(--surface-border);
 
 /// Text color of an accordion panel header in hover state
 /// @group panel

--- a/src/azion-light/variables/_panel.scss
+++ b/src/azion-light/variables/_panel.scss
@@ -108,7 +108,7 @@ $accordionHeaderHoverBg: var(--surface-hover);
 
 /// Border of an accordion panel header in hover state
 /// @group panel
-$accordionHeaderHoverBorderColor: $panelHeaderBorder;
+$accordionHeaderHoverBorderColor: var(--surface-border);
 
 /// Text color of an accordion panel header in hover state
 /// @group panel


### PR DESCRIPTION
Alterada a cor de borda do accordion no estado hover.

Antes:
![image](https://github.com/aziontech/azion-theme/assets/44036260/ce13f10c-b62c-4a29-bbce-e742c042b8ee)

Depois:
![image](https://github.com/aziontech/azion-theme/assets/44036260/e3c9128d-000c-452e-adb2-c784886545a6)
