### PR TITLE
[UXE-3433] fix: tabmenu markdown

### DIFF
--- a/src/azion-dark/extended-components/_markdown.scss
+++ b/src/azion-dark/extended-components/_markdown.scss
@@ -84,4 +84,22 @@
     font-size: 1rem;
     padding-left: .375rem;
   }
+
+  *:is(._tablist_ugdi6_34){
+    border-color: transparent !important;
+  }
+  *:is(.TabGroup) {
+    border-bottom: none !important;
+  }
+  *:is(.TabGroup > button){
+    font-weight: 500 !important;
+  }
+  *:is(.TabGroup > span){
+    color: #f3652b !important;
+    height: 10px !important;
+    background: #f3652b !important;
+  }
+  *:is(._tab-scroll-overflow_ugdi6_10 > .border){
+    border-color: var(--surface-border) !important;
+  }
 }

--- a/src/azion-light/extended-components/_markdown.scss
+++ b/src/azion-light/extended-components/_markdown.scss
@@ -84,4 +84,22 @@
     font-size: 1rem;
     padding-left: .375rem;
   }
+
+  *:is(._tablist_ugdi6_34){
+    border-color: transparent !important;
+  }
+  *:is(.TabGroup) {
+    border-bottom: none !important;
+  }
+  *:is(.TabGroup > button){
+    font-weight: 500 !important;
+  }
+  *:is(.TabGroup > span){
+    color: #f3652b !important;
+    height: 10px !important;
+    background: #f3652b !important;
+  }
+  *:is(._tab-scroll-overflow_ugdi6_10 > .border){
+    border-color: var(--surface-border) !important;
+  }
 }


### PR DESCRIPTION
Alterado em theme o markdown referente ao tabmenu.

![image](https://github.com/aziontech/azion-theme/assets/44036260/a6405d41-9d5a-4e45-ac6e-eaae815e5a64)
