### PR TITLE
fix: code markdown

### DIFF
--- a/src/azion-dark/extended-components/_markdown.scss
+++ b/src/azion-dark/extended-components/_markdown.scss
@@ -84,4 +84,11 @@
     font-size: 1rem;
     padding-left: .375rem;
   }
+
+  *:is(.expressive-code) {
+    margin-bottom: 1.8rem !important;
+  }
+  *:is(.expressive-code code) {
+    background: var(--surface-200) !important;
+  }
 }

--- a/src/azion-light/extended-components/_markdown.scss
+++ b/src/azion-light/extended-components/_markdown.scss
@@ -84,4 +84,11 @@
     font-size: 1rem;
     padding-left: .375rem;
   }
+
+  *:is(.expressive-code) {
+    margin-bottom: 1.8rem !important;
+  }
+  *:is(.expressive-code code) {
+    background: var(--surface-200) !important;
+  }
 }


### PR DESCRIPTION
A principio a maioria dos itens que estavam juntando era por causa dos codes, adicionei uma margin bottom neles e ficou melhor... também alguns code blocks estavam com um fundo que não estava visível ajustei também.

Antes / Depois
![image](https://github.com/aziontech/azion-theme/assets/44036260/fd5e94de-5d93-4d0e-bc9b-0ce65c5c6cb8)
![image](https://github.com/aziontech/azion-theme/assets/44036260/118b90d2-bd85-4040-8704-6f04bb034f9a)
