### PR TITLE
[UXE-3606] chore: margin hr markdown

### DIFF
--- a/src/azion-dark/extended-components/_markdown.scss
+++ b/src/azion-dark/extended-components/_markdown.scss
@@ -61,6 +61,13 @@
   *:is(hr) {
     border-color: var(--surface-border) !important;
   }
+  *:is(hr) ~ .heading-wrapper {
+    align-items: flex-start !important;
+    
+    *:is(h2, h3, h4, h5, h6) {
+      margin-top: 0 !important;
+    }
+  }
   
   *:is(aside.content) {
     background: #f3652b15 !important;

--- a/src/azion-light/extended-components/_markdown.scss
+++ b/src/azion-light/extended-components/_markdown.scss
@@ -61,6 +61,13 @@
   *:is(hr) {
     border-color: var(--surface-border) !important;
   }
+  *:is(hr) ~ .heading-wrapper {
+    align-items: flex-start !important;
+    
+    *:is(h2, h3, h4, h5, h6) {
+      margin-top: 0 !important;
+    }
+  }
   
   *:is(aside.content) {
     background: #f3652b15 !important;


### PR DESCRIPTION
Ajuste para que os títulos após os HR (divisões) tenham um espaçamento harmônico.

![image](https://github.com/aziontech/azion-theme/assets/44036260/cae1207f-fc9c-44da-bf36-1250b05b417c)
