### PR TITLE
chore: hover values

### DIFF
--- a/src/azion-dark/_variables.scss
+++ b/src/azion-dark/_variables.scss
@@ -100,7 +100,7 @@ $colors: (
   --surface-section: #171717;
   --surface-card: #171717;
   --surface-overlay: #ffffff;
-  --surface-border: #3e3e3e;
+  --surface-border: #282828;
   --surface-hover: #f5f5f516;
   --focus-ring: #{$focusShadow};
   --maskbg: #{$maskBg};

--- a/src/azion-dark/_variables.scss
+++ b/src/azion-dark/_variables.scss
@@ -101,7 +101,7 @@ $colors: (
   --surface-card: #171717;
   --surface-overlay: #ffffff;
   --surface-border: #3e3e3e;
-  --surface-hover: #242424;
+  --surface-hover: #f5f5f516;
   --focus-ring: #{$focusShadow};
   --maskbg: #{$maskBg};
   --highlight-bg: #{$highlightBg};

--- a/src/azion-light/_variables.scss
+++ b/src/azion-light/_variables.scss
@@ -100,7 +100,7 @@ $colors: (
   --surface-card: #ffffff;
   --surface-overlay: #ffffff;
   --surface-border: #dee2e6;
-  --surface-hover: #f4f4f4;
+  --surface-hover: #3b3b3b16;
 
   --focus-ring: #{$focusShadow};
   --maskbg: #{$maskBg};

--- a/src/azion-light/_variables.scss
+++ b/src/azion-light/_variables.scss
@@ -99,7 +99,7 @@ $colors: (
   --surface-section: #ffffff;
   --surface-card: #ffffff;
   --surface-overlay: #ffffff;
-  --surface-border: #dee2e6;
+  --surface-border: #e8e8e8;
   --surface-hover: #3b3b3b16;
 
   --focus-ring: #{$focusShadow};


### PR DESCRIPTION
Alterado os valores de hover para deixar mais claro e resolver alguns bugs de conflito com fundos coloridos.

Antes:
![image](https://github.com/aziontech/azion-theme/assets/44036260/d2184118-ffd2-494e-ba9a-896f2f00d9bb)
![image](https://github.com/aziontech/azion-theme/assets/44036260/6a770f42-1886-41d2-a53b-475e81a4f9fd)

Depois:
![image](https://github.com/aziontech/azion-theme/assets/44036260/2f7fad64-9841-4cf7-92f8-3f8f7abb0a01)
![image](https://github.com/aziontech/azion-theme/assets/44036260/ac057da8-f888-4ea2-b1f6-a41c1e9fa45f)
