### PR TITLE
[UXE-4806] fix: carousel colors indicator

### DIFF
--- a/src/azion-dark/_extensions.scss
+++ b/src/azion-dark/_extensions.scss
@@ -26,5 +26,5 @@
   @import '../azion-dark/extended-components/progressbar';
   @import '../azion-dark/extended-components/dialog';
   @import '../azion-dark/extended-components/multiselect';
-
+  @import '../azion-dark/extended-components/carousel';
 }

--- a/src/azion-dark/extended-components/_carousel.scss
+++ b/src/azion-dark/extended-components/_carousel.scss
@@ -1,0 +1,9 @@
+// Custom carousel
+
+.p-carousel-indicators {
+    .p-carousel-indicator {
+        &.p-highlight {
+            background: #fff !important;
+        }
+    }
+}

--- a/src/azion-dark/variables/_media.scss
+++ b/src/azion-dark/variables/_media.scss
@@ -4,11 +4,11 @@ $carouselIndicatorsPadding: 1rem;
 
 /// Padding of a carousel indicator
 /// @group media
-$carouselIndicatorBg: #e9ecef;
+$carouselIndicatorBg: #e9ecef20;
 
 /// Padding of a carousel indicator in hover state
 /// @group media
-$carouselIndicatorHoverBg: #dee2e6;
+$carouselIndicatorHoverBg: #dee2e640;
 
 /// Border radius of a carousel indicator
 /// @group media

--- a/src/azion-light/_extensions.scss
+++ b/src/azion-light/_extensions.scss
@@ -26,4 +26,5 @@
   @import '../azion-light/extended-components/progressbar';
   @import '../azion-light/extended-components/dialog';
   @import '../azion-light/extended-components/multiselect';
+  @import '../azion-light/extended-components/carousel';
 }

--- a/src/azion-light/extended-components/_carousel.scss
+++ b/src/azion-light/extended-components/_carousel.scss
@@ -1,0 +1,9 @@
+// Custom carousel
+
+.p-carousel-indicators {
+    .p-carousel-indicator {
+        &.p-highlight {
+            background: #171717 !important;
+        }
+    }
+}


### PR DESCRIPTION
Corrigido uma visualização onde em darkmode aparentava estar ao contrário a lógica do carousel indicador ativo.

Como estava:
![image](https://github.com/user-attachments/assets/a05ead11-a5fb-4a65-83fc-2550384d0c65)

Corrigido:
![image](https://github.com/user-attachments/assets/3089ea10-3c0c-455b-9e84-54f03b539af4)
