### PR TITLE
chore: no hover datatable empty

### DIFF
--- a/src/azion-dark/extended-components/_datatable.scss
+++ b/src/azion-dark/extended-components/_datatable.scss
@@ -9,6 +9,10 @@
     border-top-left-radius: $borderRadius;
   }
 
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
+  }
+
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;

--- a/src/azion-light/extended-components/_datatable.scss
+++ b/src/azion-light/extended-components/_datatable.scss
@@ -9,6 +9,10 @@
     border-top-left-radius: $borderRadius;
   }
 
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
+  }
+
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;

--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -9,6 +9,10 @@
     border-top-left-radius: $borderRadius;
   }
 
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
+  }
+
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;


### PR DESCRIPTION
Previne o efeito de hover nos empty blocks das datatables uma vez que eles também estavam sendo afetados pelo efeito de hover dos tr > td, agora não estão mais.

![image](https://github.com/user-attachments/assets/b206a124-f482-4d97-bcc5-be57841194ea)
