### PR TITLE
fix: hover emptydatatable

### DIFF
--- a/src/azion-dark/extended-components/_datatable.scss
+++ b/src/azion-dark/extended-components/_datatable.scss
@@ -9,6 +9,10 @@
     border-top-left-radius: $borderRadius;
   }
 
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
+  }
+
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;

--- a/src/azion-dark/extended-components/_datatable.scss
+++ b/src/azion-dark/extended-components/_datatable.scss
@@ -9,10 +9,6 @@
     border-top-left-radius: $borderRadius;
   }
 
-  .p-datatable-tbody > .p-datatable-emptymessage:hover {
-    background: unset !important;
-  }
-
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;
@@ -55,6 +51,10 @@
   
   .p-datatable-wrapper {
     overscroll-behavior: revert !important;
+  }
+
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
   }
 }
 

--- a/src/azion-light/extended-components/_datatable.scss
+++ b/src/azion-light/extended-components/_datatable.scss
@@ -9,10 +9,6 @@
     border-top-left-radius: $borderRadius;
   }
 
-  .p-datatable-tbody > .p-datatable-emptymessage:hover {
-    background: unset !important;
-  }
-
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;
@@ -57,6 +53,10 @@
 
   .p-datatable-wrapper {
     overscroll-behavior: revert !important;
+  }
+
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
   }
 }
 

--- a/src/azion-light/extended-components/_datatable.scss
+++ b/src/azion-light/extended-components/_datatable.scss
@@ -9,6 +9,10 @@
     border-top-left-radius: $borderRadius;
   }
 
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
+  }
+
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;

--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -9,6 +9,10 @@
     border-top-left-radius: $borderRadius;
   }
 
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
+  }
+
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;

--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -9,10 +9,6 @@
     border-top-left-radius: $borderRadius;
   }
 
-  .p-datatable-tbody > .p-datatable-emptymessage:hover {
-    background: unset !important;
-  }
-
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;
@@ -55,6 +51,10 @@
   
   .p-datatable-wrapper {
     overscroll-behavior: revert !important;
+  }
+
+  .p-datatable-tbody > .p-datatable-emptymessage:hover {
+    background: unset !important;
   }
 }
 


### PR DESCRIPTION
Same of the last pr, but now with the correct prefix to trigger the pipeline.

Previne o efeito de hover nos empty blocks das datatables uma vez que eles também estavam sendo afetados pelo efeito de hover dos tr > td, agora não estão mais.

![image](https://github.com/user-attachments/assets/920cb9cc-a219-4ac2-b2a3-7f85d6b3a2a4)
