### PR TITLE
chore: font-face using only woff2

### DIFF
--- a/src/azion/_fonts.scss
+++ b/src/azion/_fonts.scss
@@ -1,14 +1,79 @@
-// Configuration for the font-face of the theme, defaults to the system font so left as blank
 @font-face {
   font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-light.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-light.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-light.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-light.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-light.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-light.svg#roboto-light') format('svg');
+  src: url('https://fonts.azion.com/roboto/roboto-light.woff2') format('woff2');
   font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-italic.woff2') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-medium.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-mediumitalic.woff2') format('woff2');
+  font-weight: 500;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-bold.woff2') format('woff2');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-bold.woff2') format('woff2');
+  font-weight: bold;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-bolditalic.woff2') format('woff2');
+  font-weight: bold;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-bolditalic.woff2') format('woff2');
+  font-weight: 600;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src: url('https://fonts.azion.com/roboto/roboto-black.woff2') format('woff2');
+  font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
@@ -25,132 +90,6 @@
   font-family: 'Roboto Mono';
   src: url('https://fonts.azion.com/roboto-mono/roboto-mono-light.ttf') format('truetype');
   font-weight: 300;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-regular.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-regular.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-regular.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-regular.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-regular.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-regular.svg#Roboto-Regular') format('svg');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-italic.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-italic.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-italic.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-italic.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-italic.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-italic.svg#roboto-italic') format('svg');
-  font-weight: 400;
-  font-style: italic;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-medium.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-medium.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-medium.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-medium.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-medium.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-medium.svg#roboto-medium') format('svg');
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-mediumitalic.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-mediumitalic.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-mediumitalic.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-mediumitalic.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-mediumitalic.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-mediumitalic.svg#roboto-mediumitalic') format('svg');
-  font-weight: 500;
-  font-style: italic;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-bold.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-bold.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-bold.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-bold.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-bold.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-bold.svg#roboto-bold') format('svg');
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-bold.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-bold.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-bold.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-bold.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-bold.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-bold.svg#roboto-bold') format('svg');
-  font-weight: bold;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-bolditalic.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.svg#roboto-bolditalic') format('svg');
-  font-weight: bold;
-  font-style: italic;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-bolditalic.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-bolditalic.svg#roboto-bold') format('svg');
-  font-weight: 600;
-  font-style: italic;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('https://fonts.azion.com/roboto/roboto-black.eot');
-  src:
-    url('https://fonts.azion.com/roboto/roboto-black.eot?#iefix') format('embedded-opentype'),
-    url('https://fonts.azion.com/roboto/roboto-black.woff2') format('woff2'),
-    url('https://fonts.azion.com/roboto/roboto-black.woff') format('woff'),
-    url('https://fonts.azion.com/roboto/roboto-black.ttf') format('truetype'),
-    url('https://fonts.azion.com/roboto/roboto-black.svg#roboto-black') format('svg');
-  font-weight: 700;
   font-style: normal;
   font-display: swap;
 }


### PR DESCRIPTION
**Task Description:**

To improve our performance loading using the modern browsers features we detect that is not necessary to use a lot of fonts-faces type. Nowadays exist the woff2 and it is supported by all the modern browsers.

https://caniuse.com/woff2

<img width="1436" alt="Screenshot 2024-12-06 at 12 14 27" src="https://github.com/user-attachments/assets/7ceab9cb-ee8f-4a5c-b7f0-fede1bf3629f">


**Wha is changed?**

<img width="1440" alt="Screenshot 2024-12-06 at 12 12 37" src="https://github.com/user-attachments/assets/79c1825d-630d-4b24-960c-c0d99e6140c7">

Note the 2 font resources using woff. The time taking 200ms to both calls, with this modification we will not load this extra-resources.


**Current network requests**

<img width="1437" alt="Screenshot 2024-12-06 at 12 57 15" src="https://github.com/user-attachments/assets/a6ca3411-e601-49b7-b841-e402cc89b55c">

