### PR TITLE
fix: checkbox icon color

### DIFF
--- a/src/azion/extended-components/_checkbox.scss
+++ b/src/azion/extended-components/_checkbox.scss
@@ -3,7 +3,7 @@
   .p-checkbox-box {
     border: 2px solid var(--surface-border) !important;
     .p-checkbox-icon {
-      color: white !important;
+      color: var(--text-color) !important;
     }
 
     &.p-highlight {


### PR DESCRIPTION
Ajustado cor do icon de checkbox que no light-mode estava ficando sempre branco.

Antes:
![image](https://github.com/user-attachments/assets/0a47076a-0b14-4377-b4fb-0cbded4d6b8d)

Depois:
![image](https://github.com/user-attachments/assets/b4f93fed-02db-479f-95d9-74704bce1403)
