### PR TITLE
fix: empty results color

### DIFF
--- a/src/azion/_extensions.scss
+++ b/src/azion/_extensions.scss
@@ -27,4 +27,6 @@
   @import './extended-components/dialog';
   @import './extended-components/multiselect';
   @import './extended-components/carousel';
+  @import './extended-components/dropdown';
+  @import './extended-components/treeselect';
 }

--- a/src/azion/_variables.scss
+++ b/src/azion/_variables.scss
@@ -77,6 +77,7 @@ $colors: (
   --text-color-secondary: #b5b5b5;
   --text-color-link: #93c5fd;
   --text-color-link-hover: #93c5fd;
+  --text-color-empty: var(--surface-800);
 
   --surface-0: #0a0a0a;
   --surface-50: #111111;
@@ -243,6 +244,7 @@ $colors: (
   --text-color-secondary: #666666;
   --text-color-link: #3265cb;
   --text-color-link-hover: #2851a4;
+  --text-color-empty: var(--surface-800);
   --degrade-primary: 0, 0, 0;
   --degrade-secondary: 255, 255, 255;
 

--- a/src/azion/extended-components/_dropdown.scss
+++ b/src/azion/extended-components/_dropdown.scss
@@ -1,0 +1,10 @@
+.p-dropdown-panel {
+
+    .p-dropdown-items {
+
+        .p-dropdown-empty-message {
+            color: var(--text-color-empty);
+            font-size: 14px;
+        }
+    }
+}

--- a/src/azion/extended-components/_listbox.scss
+++ b/src/azion/extended-components/_listbox.scss
@@ -21,5 +21,12 @@
       outline-offset: $focusOutlineOffset !important;
       box-shadow: $focusShadow !important;
     }
+    .p-listbox-item{
+      
+      .p-listbox-empty-message {
+        color: var(--text-color-empty);
+        font-size: 14px;
+      }
+    }
   }
 }

--- a/src/azion/extended-components/_multiselect.scss
+++ b/src/azion/extended-components/_multiselect.scss
@@ -148,9 +148,8 @@
     }
 
     .p-multiselect-empty-message {
-      padding: $inputListItemPadding;
-      color: $inputListItemTextColor;
-      background: $inputListItemBg;
+      color: var(--text-color-empty);
+      font-size: 14px;
     }
   }
 }

--- a/src/azion/extended-components/_treeselect.scss
+++ b/src/azion/extended-components/_treeselect.scss
@@ -1,0 +1,10 @@
+.p-treeselect-panel {
+
+    .p-treeselect-items-wrapper {
+
+        .p-treeselect-empty-message {
+            color: var(--text-color-empty);
+            font-size: 14px;
+        }
+    }
+}


### PR DESCRIPTION
Adicionado token de cor para resultados vazios para componentes que mostram lista de resultado

Antes:
![image](https://github.com/user-attachments/assets/9201a19a-3b42-4d04-87ba-234b342145c9)


Depois:
![image](https://github.com/user-attachments/assets/eadcace9-25ee-4069-a397-7b9668fdd8ed)
