### PR TITLE
fix: readable content code block colors

### DIFF
--- a/src/azion/extended-components/_markdown.scss
+++ b/src/azion/extended-components/_markdown.scss
@@ -1,5 +1,5 @@
 .prose {
-  *:not(p, a, li) {
+  *:not(p, a, li, span) {
     color: var(--text-color) !important;
   }
 

--- a/src/azion/extended-components/_markdown.scss
+++ b/src/azion/extended-components/_markdown.scss
@@ -115,7 +115,7 @@
     margin-bottom: 1.8rem !important;
   }
   *:is(.expressive-code code) {
-    background: var(--surface-200) !important;
+    background: #222222 !important;
   }
   *:is(.p-button) {
     margin: 0 .5rem .5rem 0;


### PR DESCRIPTION
Só mergear depois de definido como ficará as cores em light mode. Isso habilitará o "syntax highlight" nos codes blocks do Readable Content.