### PR TITLE
fix: adjust background color for frozen column on datatable

### DIFF
--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -16,6 +16,10 @@
   .p-datatable-tbody > tr > td {
     box-sizing: inherit !important;
     font-size: 0.875rem;
+
+    .p-frozen-column {
+      background: none !important;
+    }
   }
 
   .p-datatable-thead > tr > th {

--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -22,6 +22,10 @@
     }
   }
 
+  .p-datatable-scrollable .p-frozen-column {
+    background: none !important;
+  }
+
   .p-datatable-thead > tr > th {
     box-sizing: inherit !important;
     font-size: 0.875rem;

--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -4,6 +4,12 @@
   font-size: 0.875rem !important;
   text-wrap: nowrap !important;
 
+  .p-paginator {
+    border-width: 0px !important;
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+  }
+
   .p-datatable-header {
     border-top-right-radius: $borderRadius;
     border-top-left-radius: $borderRadius;

--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -13,17 +13,15 @@
     background: unset !important;
   }
 
-  .p-datatable-tbody > tr > td {
-    box-sizing: inherit !important;
-    font-size: 0.875rem;
-
+  .p-datatable-tbody {
     .p-frozen-column {
       background: none !important;
     }
   }
 
-  .p-datatable-scrollable .p-frozen-column {
-    background: none !important;
+  .p-datatable-tbody > tr > td {
+    box-sizing: inherit !important;
+    font-size: 0.875rem;
   }
 
   .p-datatable-thead > tr > th {


### PR DESCRIPTION
fix: ajuste cor de background do frozen column da datatable, removido a cor que estava conflitando em algumas situações.