### PR TITLE
fix: spacing accordion

### DIFF
--- a/src/azion/variables/_panel.scss
+++ b/src/azion/variables/_panel.scss
@@ -80,7 +80,7 @@ $panelFooterPadding: 0.5rem 1rem;
 
 /// Spacing between to accordion panels
 /// @group panel
-$accordionSpacing: 0.75rem;
+$accordionSpacing: 0.5rem;
 
 /// Border of an accordion panel header
 /// @group panel

--- a/src/azion/variables/_panel.scss
+++ b/src/azion/variables/_panel.scss
@@ -80,7 +80,7 @@ $panelFooterPadding: 0.5rem 1rem;
 
 /// Spacing between to accordion panels
 /// @group panel
-$accordionSpacing: 0;
+$accordionSpacing: 0.75rem;
 
 /// Border of an accordion panel header
 /// @group panel


### PR DESCRIPTION
Ajuste para refletir espaçamento entre accordion tabs.

Antes:
<img width="1656" height="614" alt="image" src="https://github.com/user-attachments/assets/c666815e-fe55-4220-8549-2d346842ce30" />

Depois:
<img width="1628" height="640" alt="image" src="https://github.com/user-attachments/assets/762317ee-3c51-4bf3-8c64-2439d8133661" />
