### PR TITLE
fix: calendar color and size fixes

### DIFF
--- a/src/azion/extended-components/_calendar.scss
+++ b/src/azion/extended-components/_calendar.scss
@@ -40,3 +40,271 @@
     }
   }
 }
+
+.p-datepicker {
+  padding: $calendarPadding;
+  max-width: 320px !important;
+  background: $calendarInlineBg;
+  color: $calendarTextColor;
+  border: $calendarBorder;
+  border-radius: $borderRadius;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: fit-content !important;
+
+  .p-datepicker-group-container {
+    width: fit-content !important;
+  }
+
+  &:not(.p-datepicker-inline) {
+      background: $calendarBg;
+      border: $calendarOverlayBorder;
+      box-shadow: $inputOverlayShadow;
+
+      .p-datepicker-header {
+          background: $calendarHeaderBg;
+          width: 100% !important;
+      }
+  }
+
+  .p-datepicker-header {
+      padding: 0 !important;
+      color: $calendarHeaderTextColor;
+      background: $calendarInlineHeaderBg;
+      font-weight: $calendarHeaderFontWeight;
+      margin: $inputListHeaderMargin;
+      border-bottom: $divider;
+      border-top-right-radius: $borderRadius;
+      border-top-left-radius: $borderRadius;
+
+      .p-datepicker-prev,
+      .p-datepicker-next {
+          @include action-icon();
+      }
+
+      .p-datepicker-title {
+          line-height: $actionIconHeight;
+
+          .p-datepicker-year,
+          .p-datepicker-month {
+              color: $calendarHeaderTextColor;
+              transition: $actionIconTransition;
+              font-weight: $calendarHeaderFontWeight;
+              padding: $calendarHeaderCellPadding;
+
+              &:enabled:hover {
+                  color: $calendarMonthYearHeaderHoverTextColor;
+              }
+          }
+
+          .p-datepicker-month {
+              margin-right: $inlineSpacing;
+          }
+      }
+  }
+
+  .p-datepicker-calendar-container {
+    padding: 0px !important;
+    width: fit-content !important;
+  }
+
+  table {
+      font-size: $fontSize;
+      margin: $calendarTableMargin;
+
+      th {
+          padding: 0 !important;
+
+          > span {
+              width: 32px !important;
+              height: 32px !important;
+              margin: 4px !important;
+          }
+      }
+
+      td {
+          padding: 0 !important;
+
+          > span {
+              width: 32px !important;
+              height: 32px !important;
+              margin: 4px !important;
+              border-radius: $calendarCellDateBorderRadius;
+              transition: $listItemTransition;
+              border: $calendarCellDateBorder;
+
+              &.p-highlight {
+                  color: var(--secondary-button-text-active-color);
+                  font-weight: 500 !important;
+                  background: var(--secondary-button-active-bg) !important;
+              }
+
+              &:focus {
+                  @include focused();
+              }
+          }
+
+          &.p-datepicker-today {
+              > span {
+                  background: var(--surface-500) !important;
+                  color: var(--text-color) !important;
+                  border-color: none !important;
+
+                  &.p-highlight {
+                    color: var(--primary-color-text) !important;
+                    font-weight: 500 !important;
+                    background: var(--primary-dark-color) !important;
+                  }
+              }
+          }
+      }
+  }
+
+  .p-datepicker-buttonbar {
+      padding: $calendarButtonBarPadding;
+      border-top: $divider;
+
+      .p-button {
+          width: auto;
+      }
+  }
+
+  .p-timepicker {
+      border-top: $divider;
+      padding: 0 !important;
+      width: 100% !important;
+
+      button {
+          @include action-icon();
+
+          &:last-child {
+              margin-top: .2em;
+          }
+      }
+
+      span {
+          font-size: 1rem !important;
+      }
+
+      > div {
+          padding: $calendarTimePickerElementPadding;
+      }
+  }
+
+  &.p-datepicker-timeonly {
+      .p-timepicker {
+          border-top: 0 none;
+      }
+  }
+
+  .p-monthpicker {
+      margin: $calendarTableMargin;
+
+      .p-monthpicker-month {
+          padding: $calendarCellDatePadding;
+          transition: $listItemTransition;
+          border-radius: $borderRadius;
+
+          &.p-highlight {
+              color: $highlightTextColor;
+              background: var(--surface-500) !important;
+          }
+      }
+  }
+
+  .p-yearpicker {
+      margin: $calendarTableMargin;
+
+      .p-yearpicker-year {
+          padding: $calendarCellDatePadding;
+          transition: $listItemTransition;
+          border-radius: $borderRadius;
+
+          &.p-highlight {
+              color: $highlightTextColor;
+              background: $highlightBg;
+          }
+      }
+  }
+
+  .p-datepicker-group {
+    width: 100% !important;
+  }
+
+  &.p-datepicker-multiple-month {
+      .p-datepicker-group {
+        width: 100% !important;
+          border-left: $divider;
+          padding-right: $calendarPadding;
+          padding-left: $calendarPadding;
+          padding-top: 0;
+          padding-bottom: 0;
+
+          &:first-child {
+              padding-left: 0;
+              border-left: 0 none;
+          }
+
+          &:last-child {
+              padding-right: 0;
+          }
+      }
+  }
+
+  &:not(.p-disabled) {
+      table {
+          td {
+              span:not(.p-highlight):not(.p-disabled) {
+                  &:hover {
+                      background: $calendarCellDateHoverBg;
+                  }
+
+                  &:focus {
+                      @include focused();
+                  }
+              }
+          }
+      }
+
+      .p-monthpicker {
+          .p-monthpicker-month {
+              &:not(.p-disabled) {
+                  &:not(.p-highlight):hover {
+                      background: $calendarCellDateHoverBg;
+                  }
+
+                  &:focus {
+                      @include focused();
+                  }
+              }
+          }
+      }
+
+      .p-yearpicker {
+          .p-yearpicker-year {
+              &:not(.p-disabled) {
+                  &:not(.p-highlight):hover {
+                      background: $calendarCellDateHoverBg;
+                  }
+
+                  &:focus {
+                      @include focused();
+                  }
+              }
+          }
+      }
+  }
+
+}
+
+@media screen and (max-width: $calendarBreakpoint) {
+  .p-datepicker {
+      table {
+          th, td {
+              padding: $calendarCellDatePaddingSM;
+          }
+      }
+  }
+}

--- a/src/azion/extended-components/_calendar.scss
+++ b/src/azion/extended-components/_calendar.scss
@@ -173,7 +173,7 @@
 
   .p-timepicker {
       border-top: $divider;
-      padding: 0 !important;
+      padding: 0;
       width: 100% !important;
 
       button {

--- a/src/azion/extended-components/_calendar.scss
+++ b/src/azion/extended-components/_calendar.scss
@@ -148,14 +148,14 @@
 
           &.p-datepicker-today {
               > span {
-                  background: var(--surface-500) !important;
-                  color: var(--text-color) !important;
-                  border-color: none !important;
+                  background: var(--surface-500);
+                  color: var(--text-color);
+                  border-color: none;
 
                   &.p-highlight {
-                    color: var(--primary-color-text) !important;
-                    font-weight: 500 !important;
-                    background: var(--primary-dark-color) !important;
+                    color: var(--primary-color-text);
+                    font-weight: 500;
+                    background: var(--primary-dark-color);
                   }
               }
           }
@@ -209,7 +209,7 @@
 
           &.p-highlight {
               color: $highlightTextColor;
-              background: var(--surface-500) !important;
+              background: $highlightBg;
           }
       }
   }


### PR DESCRIPTION
[UXE-7092] fixed calendar color and sizes to reflect in real time metrics/events and personal tokens usage

before:
<img width="2880" height="1572" alt="image" src="https://github.com/user-attachments/assets/74532192-e724-443d-8e23-0588e4bd7595" />
<img width="2880" height="1570" alt="image" src="https://github.com/user-attachments/assets/c3b745bb-98a3-41d1-a622-27ef7718ed33" />

after:
<img width="2880" height="1576" alt="image" src="https://github.com/user-attachments/assets/a21551a6-9378-4ed4-bcb2-a01780b88977" />
<img width="2880" height="1572" alt="image" src="https://github.com/user-attachments/assets/01332f95-9014-4f78-b6db-fb27e2ea1edf" />


[UXE-7092]: https://aziontech.atlassian.net/browse/UXE-7092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ