### PR TITLE
fix: checkbox color checked fix

### DIFF
--- a/src/azion/extended-components/_checkbox.scss
+++ b/src/azion/extended-components/_checkbox.scss
@@ -2,9 +2,6 @@
 .p-checkbox {
   .p-checkbox-box {
     border: 2px solid var(--surface-border) !important;
-    .p-checkbox-icon {
-      color: var(--text-color) !important;
-    }
 
     &.p-highlight {
       border-color: #f3652b !important;


### PR DESCRIPTION
fixed an issue that the checked color was black (incorrect) in light mode

after:
<img width="1674" height="662" alt="image" src="https://github.com/user-attachments/assets/93f9bee6-b3f7-4a53-9258-fbcc2ef8b816" />

before:
<img width="1658" height="766" alt="image" src="https://github.com/user-attachments/assets/9d5d0a19-edf0-44ca-be85-25c02815d4d7" />
