### PR TITLE
fix: frozen color visual bug

### DIFF
--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -21,7 +21,14 @@
 
   .p-datatable-tbody {
     .p-frozen-column {
-      background: none !important;
+      background: var(--surface-section) !important;
+      transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s !important;
+    }
+  }
+
+  .p-datatable-tbody > tr:hover {
+    .p-frozen-column {
+      background: var(--table-body-row-hover-bg) !important;
     }
   }
 


### PR DESCRIPTION
[UXE-7919](https://aziontech.atlassian.net/browse/UXE-7919)

Resolvido o bug visual onde as colunas do tipo frozen columns ficavam com o fundo transparente e ficavam acima das demais colunas:

<img width="886" height="970" alt="image" src="https://github.com/user-attachments/assets/a5b23d44-167f-4db9-87c0-d2d1777e5c1f" />
