### PR TITLE
fix: removed focus on table row, not necessary anymore

### DIFF
--- a/src/azion/extended-components/_datatable.scss
+++ b/src/azion/extended-components/_datatable.scss
@@ -19,6 +19,10 @@
     background: unset !important;
   }
 
+  .p-datatable-tbody > tr:focus-visible {
+    outline: none !important;
+  }
+
   .p-datatable-tbody {
     .p-frozen-column {
       background: var(--table-body-row-even-bg);


### PR DESCRIPTION
removido o outline de focus visible da table row que estava gerando um comportamento estranho nas tabelas, uma vez que agora as rows não são mais clicáveis não é mais necessário esse comportamento

<img width="1440" height="783" alt="image" src="https://github.com/user-attachments/assets/bbac9099-1370-468c-bb08-f117f8d7ee86" />